### PR TITLE
Prepare for snu_python 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0
+
+- Prepare for snu_python 1.0
+
 # 0.2.0
 
 - Replace python with poise-python

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'sysadmin@socrata.com'
 license 'All rights reserved'
 description 'Installs and configures Bucky'
 long_description 'Installs and configures Bucky'
-version '0.2.0'
+version '0.3.0'
 chef_version '>= 12.1'
 
 source_url 'https://github.com/socrata-cookbooks/bucky'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,8 @@
 include_recipe 'snu_python'
 include_recipe 'runit'
 
-snu_python_package 'bucky' do
+python_package 'bucky' do
+  python '2'
   version node['bucky']['version']
 end
 

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -15,7 +15,7 @@ describe 'bucky::default' do
   end
 
   it 'installs the python package bucky' do
-    expect(chef_run).to install_snu_python_package('bucky')
+    expect(chef_run).to install_python_package('bucky').with(python: '2')
   end
 
   it 'creates bucky dir' do


### PR DESCRIPTION
We're getting rid of all the custom resources. They required too much code just
to save the extra `python '2'` line.